### PR TITLE
Add final report overlay and enhance game event tracking

### DIFF
--- a/.cursor/rules/squadtracker-rules.mdc
+++ b/.cursor/rules/squadtracker-rules.mdc
@@ -102,6 +102,13 @@ Notes:
 - App → Device: `MY_STATUS <alive|dead|help|medic>` is always sent in lowercase within the snapshot block so the device can render status consistently.
 
 #### Schema Details (provided DDL)
+- `game_events`
+  - Columns: `id` (bigserial PK), `created_at`, `occurred_at`, `game_id`, `squad_id`, `user_id` nullable, `event_type` enum, `payload` jsonb.
+  - Event types: `KILL`, `DEATH`, `STATUS_CHANGE`, `JOIN`, `LEAVE`, `GAME_STARTED`, `GAME_ENDED`, `HOST_TRANSFER`.
+  - FKs: `game_id` → `squad_games.id` (ON DELETE CASCADE), `squad_id` → `squads.id` (ON DELETE CASCADE), `user_id` → `users.id` (ON DELETE SET NULL).
+  - Indexes: `game_events_game_id_idx` on `(game_id, occurred_at)`, `game_events_squad_id_idx` on `(squad_id, occurred_at)`.
+  - Purpose: Battle log and game history tracking for final reports.
+
 - `game_rules`
   - Columns: `id` (identity PK), `created_at`, `time_before_death` default 30, `time_before_respawn` default 10, `squad_id`.
   - Constraints: `game_rules_pkey` (PK id), `game_rules_squad_id_key` (UNIQUE squad_id).
@@ -116,20 +123,30 @@ Notes:
   - Columns: `squad_id`, `game_id`, `user_id`, `username`, `kills`, `deaths`, `user_status`, `respawn_available_at`.
   - Sources: join `squad_games sg` + `user_game_stats ugs` + `users u`.
 
+- `scoreboard_final` (VIEW)
+  - Purpose: Final scoreboard for ended games (only where `squad_games.ended_at IS NOT NULL`).
+  - Columns: `game_id`, `squad_id`, `user_id`, `username`, `kills`, `deaths`, `user_status`, `max_kill_streak`.
+  - Sources: join `user_game_stats ugs` + `squad_games sg` + `users u`.
+  - Security: `security_invoker = on` to respect underlying RLS.
+
 - `squad_games`
   - Columns: `id` (bigserial PK), `created_at`, `started_at` default now(), `ended_at` nullable, `squad_id` (required), `host_user_id` nullable.
   - Constraints: `squad_games_pkey` (PK id), `ended_after_started` CHECK (ended_at null or >= started_at).
   - FKs: `host_user_id` → `users.id`, `squad_id` → `squads.id`.
   - Index: `one_active_game_per_squad` UNIQUE on `squad_id` WHERE `ended_at IS NULL`.
+  - Triggers: Auto-log `GAME_STARTED` on INSERT, `GAME_ENDED` when `ended_at` transitions from NULL to non-NULL.
 
 - `squads`
   - Columns: `id` (identity PK), `created_at`, `name`, `uuid` default `substring(md5(random()::text),1,6)`.
   - Constraints: `squads_pkey` (PK id), `squads_id_key` (UNIQUE id), `squads_uuid_key` (UNIQUE uuid).
 
 - `user_game_stats`
-  - Columns: `id` (bigserial PK), `game_id`, `user_id`, `kills` default 0, `deaths` default 0, `user_status` enum default `ALIVE`, `joined_at`, `last_status_change_at`, `respawn_available_at` nullable, `left_at` nullable.
+  - Columns: `id` (bigserial PK), `game_id`, `user_id`, `kills` default 0, `deaths` default 0, `user_status` enum default `ALIVE`, `joined_at`, `last_status_change_at`, `respawn_available_at` nullable, `left_at` nullable, `max_kill_streak` default 0, `current_kill_streak` default 0.
   - Constraints: `user_game_stats_pkey` (PK id), `user_game_stats_unique` (UNIQUE game_id, user_id).
   - FKs: `game_id` → `squad_games.id` (ON DELETE CASCADE), `user_id` → `users.id`.
+  - Triggers: 
+    - `user_game_stats_bu_streaks` BEFORE UPDATE: auto-maintain kill streak counters (increment on kills, reset on deaths/status=DEAD).
+    - `user_game_stats_au_events` AFTER UPDATE: auto-log `KILL`, `DEATH`, `STATUS_CHANGE` events to `game_events`.
 
 - `user_squad_locations`
   - Columns: `id` (identity PK), `created_at`, `updated_at` default now(), `user_id` default `auth.uid()` (required), `squad_id` (required), `longitude`, `latitude`, `direction`.
@@ -146,6 +163,8 @@ Notes:
     - `user_squad_sessions_trigger` AFTER INSERT/DELETE/UPDATE executes `manage_user_squad_locations()`.
     - `user_squad_sessions_biu_host` BEFORE INSERT or UPDATE OF `is_active` executes `auto_assign_host_on_insert_update()`.
     - `user_squad_sessions_aud_host` AFTER UPDATE OF `is_active`, `is_host` OR DELETE executes `reassign_host_if_needed()`.
+    - `user_squad_sessions_au_join_leave` AFTER INSERT/UPDATE OF `is_active`: auto-log `JOIN`/`LEAVE` events during active games.
+    - `user_squad_sessions_au_host_transfer` AFTER UPDATE OF `is_host`: auto-log `HOST_TRANSFER` events during active games.
   - Host rules:
     - Hosts must be active. On deactivation, session is automatically demoted from host.
     - When the host leaves (deactivates or session deleted), transfer host to another active member if any (oldest by `created_at`).
@@ -161,8 +180,24 @@ Notes:
   - FKs: `id` → `auth.users(id)` (ON UPDATE CASCADE, ON DELETE SET DEFAULT), `main_role` → `roles(name)` (ON UPDATE CASCADE, ON DELETE SET NULL).
 
 #### RLS Policies (current)
+- `game_events`
+  - SELECT: role `public`; qual: requester is active member of the same squad:
+    `(EXISTS (SELECT 1 FROM user_squad_sessions uss WHERE uss.squad_id = game_events.squad_id AND uss.user_id = auth.uid() AND uss.is_active = true))`
+  - INSERT: role `authenticated`; with_check: requester is active member of the same squad:
+    `(EXISTS (SELECT 1 FROM user_squad_sessions uss WHERE uss.squad_id = squad_id AND uss.user_id = auth.uid() AND uss.is_active = true))`
+- `game_rules`
+  - SELECT: role `public`; qual: requester is active in the same squad:
+    `(EXISTS (SELECT 1 FROM user_squad_sessions uss WHERE uss.squad_id = game_rules.squad_id AND uss.user_id = auth.uid() AND uss.is_active = true))`
+  - INSERT/UPDATE/DELETE: role `authenticated`; qual + with_check: requester is active host in the same squad:
+    `((SELECT auth.uid()) IN (SELECT uss1.user_id FROM user_squad_sessions uss1 WHERE uss1.squad_id = game_rules.squad_id AND uss1.is_active = true AND uss1.is_host = true))`
 - `roles`
   - SELECT: role `public`; qual: `true`.
+- `scoreboard_current` (VIEW)
+  - View executes with security invoker to respect underlying table RLS:
+    `ALTER VIEW scoreboard_current SET (security_invoker = on);`
+- `scoreboard_final` (VIEW)
+  - View executes with security invoker to respect underlying table RLS:
+    `ALTER VIEW scoreboard_final SET (security_invoker = on);`
 - `squad_games`
   - SELECT: role `public`; qual: EXISTS user session in same squad and active:
     `(EXISTS (SELECT 1 FROM user_squad_sessions uss WHERE uss.squad_id = squad_games.squad_id AND uss.user_id = auth.uid() AND uss.is_active = true))`
@@ -190,29 +225,34 @@ Notes:
   - INSERT: role `public`; with_check: `auth.uid() = id` (two identical policies present).
   - UPDATE: role `public`; qual: `auth.uid() = id` (two identical policies present).
 
-Additional policies to enforce:
-- `game_rules`
-  - SELECT: role `public`; qual: requester is active in the same squad:
-    `(EXISTS (SELECT 1 FROM user_squad_sessions uss WHERE uss.squad_id = game_rules.squad_id AND uss.user_id = auth.uid() AND uss.is_active = true))`
-  - INSERT/UPDATE/DELETE: role `authenticated`; qual + with_check: requester is active host in the same squad:
-    `((SELECT auth.uid()) IN (SELECT uss1.user_id FROM user_squad_sessions uss1 WHERE uss1.squad_id = game_rules.squad_id AND uss1.is_active = true AND uss1.is_host = true))`
-- `scoreboard_current` (VIEW)
-  - View executes with security invoker to respect underlying table RLS:
-    `ALTER VIEW scoreboard_current SET (security_invoker = on);`
-
 ### Mobile App Screens (Flutter)
 - Login (via magic link): Supabase + Resend.
 - User: change name, color, role; disconnect.
 - Squads: join/create squads; view members; see if a game is ongoing; invite users; leave squad; host-only: start game, kick user, reassign host.
+- Squad Lobby:
+  - Game controls: start/end game (host only), game timer display.
+  - Squad members list with host controls.
+  - Past games button: navigates to dedicated past games screen.
+- Past Games Screen:
+  - List of ended games with date, duration, game ID.
+  - "View report" button opens final report overlay for each game.
+  - Pull-to-refresh functionality.
 - Map (Mapbox):
   - Shows members' locations with markers based on status (alive, dead, need medic/help).
   - Controls: center/follow user position.
   - Battle log: events (kills, deaths, status changes, joins/leaves).
   - Game timer when ongoing.
+  - Auto-triggers final report overlay when game ends.
   - FABs → bottom sheets:
     - Members: list with score, status, distance, bearing; sorting by kills, K/D, distance.
     - Actions: toggle statuses (Died, Send help, Send medic). Untoggling returns to Alive. Increment kills. (Future: objective contributions.)
     - Location: currently disable geolocation.
+- Final Report Overlay:
+  - Full-screen modal triggered automatically on game end or manually from past games.
+  - Two tabs: Leaderboard and History.
+  - Leaderboard: sortable by kills, K/D ratio, kill streak; shows rank, username, stats, streak badge.
+  - History: chronological list of game events with icons and timestamps.
+  - Back to Lobby and Share buttons.
 - Tracker: scan BLE devices; connect to user's TTGO; persist device ID for auto-reconnect.
 
 ### Mapping/Keys
@@ -256,15 +296,18 @@ Additional policies to enforce:
 - Create squads; members set username, color, role.
 - Configure game rules per squad/game.
 - Start/stop games; create new ones.
-- Track per-user/per-game stats: kills, deaths, status; show per-game scorecards.
+- Track per-user/per-game stats: kills, deaths, status, kill streaks; show per-game scorecards.
+- End-of-game experience: automatic final report overlay with leaderboard and battle history.
+- Historical game browsing: access past game results and reports from squad lobby.
 
 ### Roadmap / Future
 - TTGO UI:
   - Compass-style view indicating direction to each member.
 - App gameplay/config:
-  - Add i18n in the whole app
   - Define flexible game modes for multiple scenarios.
   - Map editing for objectives and markers (spawn points, objectives, misc markers).
+  - Pagination for game history when events >500.
+  - Share functionality for final reports.
 - Connectivity (later):
   - Explore switching/bridging between cellular data and LoRa for communications.
 
@@ -282,3 +325,14 @@ Additional policies to enforce:
   - Roadmap items completed or new ones added
 - Update the "Assumptions / To Clarify" section as items are resolved.
 - When providing new schema/RLS/enum details, update the relevant sections immediately.
+
+### Recent Updates
+- **Final Report Overlay Feature (2025-01-20)**:
+  - Added `game_events` table for battle log tracking with auto-logging triggers.
+  - Added kill streak tracking (`max_kill_streak`, `current_kill_streak`) to `user_game_stats`.
+  - Added `scoreboard_final` view for ended game scoreboards.
+  - Implemented automatic end-of-game detection and overlay trigger.
+  - Added dedicated Past Games screen accessible from squad lobby.
+  - Added Final Report Overlay with Leaderboard and History tabs.
+  - Added i18n support for new UI elements (EN/FR).
+  - Updated GameService with final report queries and game end detection streams.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,5 +143,12 @@
   "endedJustNow": "Ended just now",
   "killsLabel": "Kills",
   "deathsLabel": "Deaths"
+  ,
+  "killedEnemy": "killed an enemy",
+  "died": "died",
+  "respawned": "respawned",
+  "askForHelp": "asked for help",
+  "askForMedic": "asked for medic",
+  "hostTransferred": "Host transferred"
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -125,6 +125,23 @@
   "failedToDecrementDeath": "Failed to decrement death",
   "statusActions": "Status",
   "noSquadSelected": "No squad selected",
-  "mustBeAliveToKill": "You must be alive to record kills"
+  "mustBeAliveToKill": "You must be alive to record kills",
+  "finalReportTitle": "Final report",
+  "leaderboardTab": "Leaderboard",
+  "historyTab": "History",
+  "sortByKills": "Sort by Kills",
+  "sortByKDR": "Sort by K/D",
+  "sortByStreak": "Sort by Streak",
+  "kdLabel": "K/D",
+  "streakLabel": "Streak",
+  "noEventsYet": "No events yet",
+  "backToLobby": "Back to Lobby",
+  "share": "Share",
+  "viewReport": "View report",
+  "pastGamesTitle": "Past games",
+  "durationLabel": "Duration",
+  "endedJustNow": "Ended just now",
+  "killsLabel": "Kills",
+  "deathsLabel": "Deaths"
 }
 

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -125,6 +125,23 @@
   "failedToDecrementDeath": "Échec de la décrémentation de la mort",
   "statusActions": "Statut",
   "noSquadSelected": "Aucune escouade sélectionnée",
-  "mustBeAliveToKill": "Vous devez être vivant pour enregistrer des éliminations"
+  "mustBeAliveToKill": "Vous devez être vivant pour enregistrer des éliminations",
+  "finalReportTitle": "Rapport final",
+  "leaderboardTab": "Classement",
+  "historyTab": "Historique",
+  "sortByKills": "Trier par éliminations",
+  "sortByKDR": "Trier par K/D",
+  "sortByStreak": "Trier par série",
+  "kdLabel": "K/D",
+  "streakLabel": "Série",
+  "noEventsYet": "Aucun événement pour l'instant",
+  "backToLobby": "Retour au salon",
+  "share": "Partager",
+  "viewReport": "Voir le rapport",
+  "pastGamesTitle": "Parties passées",
+  "durationLabel": "Durée",
+  "endedJustNow": "Terminé à l'instant",
+  "killsLabel": "Éliminations",
+  "deathsLabel": "Morts"
 }
 

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -142,6 +142,12 @@
   "durationLabel": "Durée",
   "endedJustNow": "Terminé à l'instant",
   "killsLabel": "Éliminations",
-  "deathsLabel": "Morts"
+  "deathsLabel": "Morts",
+  "killedEnemy": "a éliminé un ennemi",
+  "died": "est mort",
+  "respawned": "a réapparu",
+  "askForHelp": "demande de l'aide",
+  "askForMedic": "demande un médic",
+  "hostTransferred": "Transfert d'hôte"
 }
 

--- a/lib/l10n/gen/app_localizations.dart
+++ b/lib/l10n/gen/app_localizations.dart
@@ -811,6 +811,108 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You must be alive to record kills'**
   String get mustBeAliveToKill;
+
+  /// No description provided for @finalReportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Final report'**
+  String get finalReportTitle;
+
+  /// No description provided for @leaderboardTab.
+  ///
+  /// In en, this message translates to:
+  /// **'Leaderboard'**
+  String get leaderboardTab;
+
+  /// No description provided for @historyTab.
+  ///
+  /// In en, this message translates to:
+  /// **'History'**
+  String get historyTab;
+
+  /// No description provided for @sortByKills.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort by Kills'**
+  String get sortByKills;
+
+  /// No description provided for @sortByKDR.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort by K/D'**
+  String get sortByKDR;
+
+  /// No description provided for @sortByStreak.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort by Streak'**
+  String get sortByStreak;
+
+  /// No description provided for @kdLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'K/D'**
+  String get kdLabel;
+
+  /// No description provided for @streakLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Streak'**
+  String get streakLabel;
+
+  /// No description provided for @noEventsYet.
+  ///
+  /// In en, this message translates to:
+  /// **'No events yet'**
+  String get noEventsYet;
+
+  /// No description provided for @backToLobby.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to Lobby'**
+  String get backToLobby;
+
+  /// No description provided for @share.
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get share;
+
+  /// No description provided for @viewReport.
+  ///
+  /// In en, this message translates to:
+  /// **'View report'**
+  String get viewReport;
+
+  /// No description provided for @pastGamesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Past games'**
+  String get pastGamesTitle;
+
+  /// No description provided for @durationLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Duration'**
+  String get durationLabel;
+
+  /// No description provided for @endedJustNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Ended just now'**
+  String get endedJustNow;
+
+  /// No description provided for @killsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Kills'**
+  String get killsLabel;
+
+  /// No description provided for @deathsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Deaths'**
+  String get deathsLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/gen/app_localizations.dart
+++ b/lib/l10n/gen/app_localizations.dart
@@ -913,6 +913,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Deaths'**
   String get deathsLabel;
+
+  /// No description provided for @killedEnemy.
+  ///
+  /// In en, this message translates to:
+  /// **'killed an enemy'**
+  String get killedEnemy;
+
+  /// No description provided for @died.
+  ///
+  /// In en, this message translates to:
+  /// **'died'**
+  String get died;
+
+  /// No description provided for @respawned.
+  ///
+  /// In en, this message translates to:
+  /// **'respawned'**
+  String get respawned;
+
+  /// No description provided for @askForHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'asked for help'**
+  String get askForHelp;
+
+  /// No description provided for @askForMedic.
+  ///
+  /// In en, this message translates to:
+  /// **'asked for medic'**
+  String get askForMedic;
+
+  /// No description provided for @hostTransferred.
+  ///
+  /// In en, this message translates to:
+  /// **'Host transferred'**
+  String get hostTransferred;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/gen/app_localizations_en.dart
+++ b/lib/l10n/gen/app_localizations_en.dart
@@ -439,4 +439,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deathsLabel => 'Deaths';
+
+  @override
+  String get killedEnemy => 'killed an enemy';
+
+  @override
+  String get died => 'died';
+
+  @override
+  String get respawned => 'respawned';
+
+  @override
+  String get askForHelp => 'asked for help';
+
+  @override
+  String get askForMedic => 'asked for medic';
+
+  @override
+  String get hostTransferred => 'Host transferred';
 }

--- a/lib/l10n/gen/app_localizations_en.dart
+++ b/lib/l10n/gen/app_localizations_en.dart
@@ -388,4 +388,55 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get mustBeAliveToKill => 'You must be alive to record kills';
+
+  @override
+  String get finalReportTitle => 'Final report';
+
+  @override
+  String get leaderboardTab => 'Leaderboard';
+
+  @override
+  String get historyTab => 'History';
+
+  @override
+  String get sortByKills => 'Sort by Kills';
+
+  @override
+  String get sortByKDR => 'Sort by K/D';
+
+  @override
+  String get sortByStreak => 'Sort by Streak';
+
+  @override
+  String get kdLabel => 'K/D';
+
+  @override
+  String get streakLabel => 'Streak';
+
+  @override
+  String get noEventsYet => 'No events yet';
+
+  @override
+  String get backToLobby => 'Back to Lobby';
+
+  @override
+  String get share => 'Share';
+
+  @override
+  String get viewReport => 'View report';
+
+  @override
+  String get pastGamesTitle => 'Past games';
+
+  @override
+  String get durationLabel => 'Duration';
+
+  @override
+  String get endedJustNow => 'Ended just now';
+
+  @override
+  String get killsLabel => 'Kills';
+
+  @override
+  String get deathsLabel => 'Deaths';
 }

--- a/lib/l10n/gen/app_localizations_fr.dart
+++ b/lib/l10n/gen/app_localizations_fr.dart
@@ -443,4 +443,22 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get deathsLabel => 'Morts';
+
+  @override
+  String get killedEnemy => 'a éliminé un ennemi';
+
+  @override
+  String get died => 'est mort';
+
+  @override
+  String get respawned => 'a réapparu';
+
+  @override
+  String get askForHelp => 'demande de l\'aide';
+
+  @override
+  String get askForMedic => 'demande un médic';
+
+  @override
+  String get hostTransferred => 'Transfert d\'hôte';
 }

--- a/lib/l10n/gen/app_localizations_fr.dart
+++ b/lib/l10n/gen/app_localizations_fr.dart
@@ -392,4 +392,55 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get mustBeAliveToKill =>
       'Vous devez être vivant pour enregistrer des éliminations';
+
+  @override
+  String get finalReportTitle => 'Rapport final';
+
+  @override
+  String get leaderboardTab => 'Classement';
+
+  @override
+  String get historyTab => 'Historique';
+
+  @override
+  String get sortByKills => 'Trier par éliminations';
+
+  @override
+  String get sortByKDR => 'Trier par K/D';
+
+  @override
+  String get sortByStreak => 'Trier par série';
+
+  @override
+  String get kdLabel => 'K/D';
+
+  @override
+  String get streakLabel => 'Série';
+
+  @override
+  String get noEventsYet => 'Aucun événement pour l\'instant';
+
+  @override
+  String get backToLobby => 'Retour au salon';
+
+  @override
+  String get share => 'Partager';
+
+  @override
+  String get viewReport => 'Voir le rapport';
+
+  @override
+  String get pastGamesTitle => 'Parties passées';
+
+  @override
+  String get durationLabel => 'Durée';
+
+  @override
+  String get endedJustNow => 'Terminé à l\'instant';
+
+  @override
+  String get killsLabel => 'Éliminations';
+
+  @override
+  String get deathsLabel => 'Morts';
 }

--- a/lib/l10n/localizations_extensions.dart
+++ b/lib/l10n/localizations_extensions.dart
@@ -1,0 +1,23 @@
+import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
+
+// Temporary fallback getters until gen-l10n is rerun. When generated keys exist,
+// these extension getters will be shadowed by the real ones.
+extension FinalReportStrings on AppLocalizations {
+  String get finalReportTitle => 'Final report';
+  String get leaderboardTab => 'Leaderboard';
+  String get historyTab => 'History';
+  String get sortByKills => 'Sort by Kills';
+  String get sortByKDR => 'Sort by K/D';
+  String get sortByStreak => 'Sort by Streak';
+  String get kdLabel => 'K/D';
+  String get streakLabel => 'Streak';
+  String get noEventsYet => 'No events yet';
+  String get backToLobby => 'Back to Lobby';
+  String get share => 'Share';
+  String get viewReport => 'View report';
+  String get pastGamesTitle => 'Past games';
+  String get durationLabel => 'Duration';
+  String get endedJustNow => 'Ended just now';
+  String get killsLabel => 'Kills';
+  String get deathsLabel => 'Deaths';
+}

--- a/lib/l10n/localizations_extensions.dart
+++ b/lib/l10n/localizations_extensions.dart
@@ -20,4 +20,11 @@ extension FinalReportStrings on AppLocalizations {
   String get endedJustNow => 'Ended just now';
   String get killsLabel => 'Kills';
   String get deathsLabel => 'Deaths';
+  // History labels
+  String get killedEnemy => 'killed an enemy';
+  String get died => 'died';
+  String get respawned => 'respawned';
+  String get askForHelp => 'asked for help';
+  String get askForMedic => 'asked for medic';
+  String get hostTransferred => 'Host transferred';
 }

--- a/lib/providers/game_service.dart
+++ b/lib/providers/game_service.dart
@@ -122,6 +122,25 @@ class GameService extends ChangeNotifier {
     }
   }
 
+  Future<Map<String, String>> getUsernamesByIds(List<String> userIds) async {
+    if (userIds.isEmpty) return <String, String>{};
+    try {
+      final rows = await _sb
+          .from('users')
+          .select('id, username')
+          .inFilter('id', userIds);
+      final map = <String, String>{};
+      for (final r in rows) {
+        final id = r['id'] as String?;
+        final name = r['username'] as String?;
+        if (id != null) map[id] = name ?? '';
+      }
+      return map;
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+
   Future<Map<String, dynamic>?> getActiveGameMeta(int squadId) async {
     final id = await getActiveGameId(squadId);
     if (id == null) return null;

--- a/lib/screens/map_with_location.dart
+++ b/lib/screens/map_with_location.dart
@@ -12,6 +12,7 @@ import 'package:squad_tracker_flutter/widgets/squad_members_list.dart';
 import 'package:squad_tracker_flutter/widgets/user_status_buttons.dart';
 import 'package:squad_tracker_flutter/widgets/scoreboard/final_report_overlay.dart';
 import 'package:squad_tracker_flutter/widgets/game/game_timer_chip.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MapWithLocation extends StatefulWidget {
   const MapWithLocation({super.key});
@@ -32,6 +33,7 @@ class MapWithLocationState extends State<MapWithLocation> {
   Timer? _ticker;
   Duration _elapsed = Duration.zero;
   int? _lastShownFinalGameId;
+  int? _lastSeenFinalGameId; // persisted across launches per squad
   StreamSubscription<int?>? _endedGameStreamSub;
   void _handleGeolocationToggle(bool isEnabled) {
     setState(() {
@@ -122,9 +124,15 @@ class MapWithLocationState extends State<MapWithLocation> {
     final sidStr = _squadService.currentSquad?.id;
     if (sidStr == null) return;
     final sid = int.parse(sidStr);
+    // Load last seen final report id for this squad
+    final prefs = await SharedPreferences.getInstance();
+    final seenKey = 'last_seen_final_report_' + sid.toString();
+    _lastSeenFinalGameId = prefs.getInt(seenKey);
+    // Treat last seen as already shown in this session
+    _lastShownFinalGameId = _lastSeenFinalGameId;
     // Catch-up on offline
     final latestEnded = await _gameService.getLatestEndedGameId(sid);
-    if (latestEnded != null && _lastShownFinalGameId != latestEnded) {
+    if (latestEnded != null && _lastSeenFinalGameId != latestEnded) {
       _openFinalReport(latestEnded);
     }
     _endedGameStreamSub?.cancel();
@@ -148,10 +156,26 @@ class MapWithLocationState extends State<MapWithLocation> {
       builder: (ctx) {
         return SizedBox(
           height: MediaQuery.of(ctx).size.height * 0.92,
-          child: FinalReportOverlay(gameId: gameId),
+          child: FinalReportOverlay(
+            gameId: gameId,
+            onBackToLobby: () {
+              Navigator.of(ctx).pop(); // Close the modal
+              Navigator.of(context).pushReplacementNamed('/squad-lobby');
+            },
+          ),
         );
       },
     );
+    // Persist as seen for this squad after dismissal
+    final sidStr = _squadService.currentSquad?.id;
+    if (sidStr != null) {
+      final sid = int.parse(sidStr);
+      final prefs = await SharedPreferences.getInstance();
+      final seenKey = 'last_seen_final_report_' + sid.toString();
+      await prefs.setInt(seenKey, gameId);
+      _lastSeenFinalGameId = gameId;
+      _lastShownFinalGameId = gameId;
+    }
   }
 
   @override

--- a/lib/screens/squads/lobby/lobby_screen.dart
+++ b/lib/screens/squads/lobby/lobby_screen.dart
@@ -12,8 +12,7 @@ import 'package:squad_tracker_flutter/widgets/invite_user_row.dart';
 import 'package:squad_tracker_flutter/widgets/snack_bar.dart';
 import 'package:squad_tracker_flutter/widgets/user_session_row.dart';
 import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
-import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
-import 'package:squad_tracker_flutter/widgets/scoreboard/final_report_overlay.dart';
+import 'package:squad_tracker_flutter/screens/squads/lobby/past_games_screen.dart';
 
 class SquadLobbyScreen extends StatefulWidget {
   const SquadLobbyScreen({super.key});
@@ -474,63 +473,20 @@ class SquadLobbyScreenState extends State<SquadLobbyScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            Text(
-              AppLocalizations.of(context)!.pastGamesTitle,
-              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 8),
-            FutureBuilder<List<Map<String, dynamic>>>(
-              future: gameService
-                  .listPastGames(int.parse(squadService.currentSquad!.id)),
-              builder: (context, snapshot) {
-                final rows = snapshot.data ?? const [];
-                if (rows.isEmpty) {
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0),
-                    child: Text(AppLocalizations.of(context)!.noEventsYet),
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.history),
+                title: Text(AppLocalizations.of(context)!.pastGamesTitle),
+                subtitle: const Text('View previous game results'),
+                trailing: const Icon(Icons.arrow_forward_ios),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const PastGamesScreen(),
+                    ),
                   );
-                }
-                return ListView.separated(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: rows.length,
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemBuilder: (context, index) {
-                    final g = rows[index];
-                    final started =
-                        DateTime.tryParse(g['started_at']?.toString() ?? '');
-                    final ended =
-                        DateTime.tryParse(g['ended_at']?.toString() ?? '');
-                    final dur = (started != null && ended != null)
-                        ? ended.difference(started)
-                        : null;
-                    return ListTile(
-                      title: Text(
-                          '#${g['id']} — ${started?.toLocal().toString().substring(0, 16) ?? ''}'),
-                      subtitle: Text(
-                        dur != null
-                            ? '${AppLocalizations.of(context)!.durationLabel}: ${dur.inMinutes}m'
-                            : AppLocalizations.of(context)!.endedJustNow,
-                      ),
-                      trailing: TextButton(
-                        onPressed: () async {
-                          await showModalBottomSheet(
-                            context: context,
-                            isScrollControlled: true,
-                            useSafeArea: true,
-                            builder: (ctx) => SizedBox(
-                              height: MediaQuery.of(ctx).size.height * 0.92,
-                              child: FinalReportOverlay(
-                                  gameId: (g['id'] as num).toInt()),
-                            ),
-                          );
-                        },
-                        child: Text(AppLocalizations.of(context)!.viewReport),
-                      ),
-                    );
-                  },
-                );
-              },
+                },
+              ),
             ),
             Text(
               AppLocalizations.of(context)!.squadMembers,

--- a/lib/screens/squads/lobby/past_games_screen.dart
+++ b/lib/screens/squads/lobby/past_games_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
+import 'package:squad_tracker_flutter/providers/game_service.dart';
+import 'package:squad_tracker_flutter/providers/squad_service.dart';
+import 'package:squad_tracker_flutter/widgets/scoreboard/final_report_overlay.dart';
+
+class PastGamesScreen extends StatefulWidget {
+  const PastGamesScreen({super.key});
+
+  @override
+  State<PastGamesScreen> createState() => _PastGamesScreenState();
+}
+
+class _PastGamesScreenState extends State<PastGamesScreen> {
+  final _gameService = GameService();
+  final _squadService = SquadService();
+  List<Map<String, dynamic>> _games = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPastGames();
+  }
+
+  Future<void> _loadPastGames() async {
+    final squadId = _squadService.currentSquad?.id;
+    if (squadId == null) return;
+
+    setState(() => _isLoading = true);
+    try {
+      final games = await _gameService.listPastGames(int.parse(squadId));
+      setState(() {
+        _games = games;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() => _isLoading = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to load past games: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.pastGamesTitle),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _games.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.history,
+                        size: 64,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        l10n.noEventsYet,
+                        style:
+                            Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  color: Theme.of(context).colorScheme.outline,
+                                ),
+                      ),
+                    ],
+                  ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _loadPastGames,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: _games.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final game = _games[index];
+                      final started = DateTime.tryParse(
+                          game['started_at']?.toString() ?? '');
+                      final ended =
+                          DateTime.tryParse(game['ended_at']?.toString() ?? '');
+                      final duration = (started != null && ended != null)
+                          ? ended.difference(started)
+                          : null;
+
+                      return ListTile(
+                        leading: CircleAvatar(
+                          child: Text('#${game['id']}'),
+                        ),
+                        title: Text(
+                          started?.toLocal().toString().substring(0, 16) ??
+                              'Unknown date',
+                        ),
+                        subtitle: Text(
+                          duration != null
+                              ? '${l10n.durationLabel}: ${duration.inMinutes}m'
+                              : l10n.endedJustNow,
+                        ),
+                        trailing: ElevatedButton(
+                          onPressed: () async {
+                            await showModalBottomSheet(
+                              context: context,
+                              isScrollControlled: true,
+                              useSafeArea: true,
+                              builder: (ctx) => SizedBox(
+                                height: MediaQuery.of(ctx).size.height * 0.92,
+                                child: FinalReportOverlay(
+                                    gameId: (game['id'] as num).toInt()),
+                              ),
+                            );
+                          },
+                          child: Text(l10n.viewReport),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+    );
+  }
+}

--- a/lib/screens/squads/lobby/past_games_screen.dart
+++ b/lib/screens/squads/lobby/past_games_screen.dart
@@ -116,7 +116,13 @@ class _PastGamesScreenState extends State<PastGamesScreen> {
                               builder: (ctx) => SizedBox(
                                 height: MediaQuery.of(ctx).size.height * 0.92,
                                 child: FinalReportOverlay(
-                                    gameId: (game['id'] as num).toInt()),
+                                  gameId: (game['id'] as num).toInt(),
+                                  onBackToLobby: () {
+                                    Navigator.of(ctx).pop(); // Close the modal
+                                    Navigator.of(context)
+                                        .pop(); // Go back to main lobby screen
+                                  },
+                                ),
                               ),
                             );
                           },

--- a/lib/widgets/scoreboard/final_report_overlay.dart
+++ b/lib/widgets/scoreboard/final_report_overlay.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
+import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
+import 'package:squad_tracker_flutter/widgets/scoreboard/leaderboard_view.dart';
+import 'package:squad_tracker_flutter/widgets/scoreboard/history_view.dart';
+
+class FinalReportOverlay extends StatefulWidget {
+  final int gameId;
+  const FinalReportOverlay({super.key, required this.gameId});
+
+  @override
+  State<FinalReportOverlay> createState() => _FinalReportOverlayState();
+}
+
+class _FinalReportOverlayState extends State<FinalReportOverlay>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.finalReportTitle),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: [
+            Tab(text: l10n.leaderboardTab),
+            Tab(text: l10n.historyTab),
+          ],
+        ),
+      ),
+      body: SafeArea(
+        child: TabBarView(
+          controller: _tabController,
+          children: [
+            LeaderboardView(gameId: widget.gameId),
+            HistoryView(gameId: widget.gameId),
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: () => Navigator.of(context).maybePop(),
+                child: Text(l10n.backToLobby),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  // Optional: implement share later
+                },
+                icon: const Icon(Icons.ios_share),
+                label: Text(l10n.share),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/scoreboard/final_report_overlay.dart
+++ b/lib/widgets/scoreboard/final_report_overlay.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
-import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
 import 'package:squad_tracker_flutter/widgets/scoreboard/leaderboard_view.dart';
 import 'package:squad_tracker_flutter/widgets/scoreboard/history_view.dart';
 
 class FinalReportOverlay extends StatefulWidget {
   final int gameId;
-  const FinalReportOverlay({super.key, required this.gameId});
+  final VoidCallback? onBackToLobby;
+  const FinalReportOverlay({
+    super.key,
+    required this.gameId,
+    this.onBackToLobby,
+  });
 
   @override
   State<FinalReportOverlay> createState() => _FinalReportOverlayState();
@@ -58,7 +62,13 @@ class _FinalReportOverlayState extends State<FinalReportOverlay>
             children: [
               Expanded(
                 child: OutlinedButton(
-                  onPressed: () => Navigator.of(context).maybePop(),
+                  onPressed: () {
+                    if (widget.onBackToLobby != null) {
+                      widget.onBackToLobby!();
+                    } else {
+                      Navigator.of(context).maybePop();
+                    }
+                  },
                   child: Text(l10n.backToLobby),
                 ),
               ),

--- a/lib/widgets/scoreboard/final_report_overlay.dart
+++ b/lib/widgets/scoreboard/final_report_overlay.dart
@@ -51,27 +51,29 @@ class _FinalReportOverlayState extends State<FinalReportOverlay>
           ],
         ),
       ),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Row(
-          children: [
-            Expanded(
-              child: OutlinedButton(
-                onPressed: () => Navigator.of(context).maybePop(),
-                child: Text(l10n.backToLobby),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  child: Text(l10n.backToLobby),
+                ),
               ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: ElevatedButton.icon(
-                onPressed: () {
-                  // Optional: implement share later
-                },
-                icon: const Icon(Icons.ios_share),
-                label: Text(l10n.share),
-              ),
-            )
-          ],
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    // Optional: implement share later
+                  },
+                  icon: const Icon(Icons.ios_share),
+                  label: Text(l10n.share),
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/scoreboard/history_view.dart
+++ b/lib/widgets/scoreboard/history_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
-import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
 import 'package:squad_tracker_flutter/providers/game_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class HistoryView extends StatefulWidget {
   final int gameId;
@@ -15,6 +15,7 @@ class HistoryView extends StatefulWidget {
 class _HistoryViewState extends State<HistoryView> {
   final _gameService = GameService();
   List<Map<String, dynamic>> _events = const [];
+  Map<String, String> _usernames = const {};
 
   @override
   void initState() {
@@ -24,7 +25,32 @@ class _HistoryViewState extends State<HistoryView> {
 
   Future<void> _load() async {
     final data = await _gameService.getGameEvents(widget.gameId);
-    setState(() => _events = data);
+    // Filter out STATUS_CHANGE events to DEAD since DEATH events handle this
+    final filteredData = data.where((e) {
+      if (e['event_type'] == 'STATUS_CHANGE') {
+        final payload = e['payload'] as Map<String, dynamic>?;
+        final toStatus = payload?['toStatus'] as String?;
+        return toStatus != 'DEAD';
+      }
+      return true;
+    }).toList();
+
+    // gather user ids to resolve usernames
+    final ids = <String>{};
+    for (final e in filteredData) {
+      final uid = e['user_id'] as String?;
+      if (uid != null) ids.add(uid);
+      // also capture possible targetUserId in payload
+      final payload = e['payload'];
+      if (payload is Map && payload['targetUserId'] is String) {
+        ids.add(payload['targetUserId'] as String);
+      }
+    }
+    final names = await _gameService.getUsernamesByIds(ids.toList());
+    setState(() {
+      _events = filteredData;
+      _usernames = names;
+    });
   }
 
   IconData _iconFor(String type) {
@@ -64,12 +90,77 @@ class _HistoryViewState extends State<HistoryView> {
         final type = (e['event_type'] as String?) ?? '';
         final tsStr = (e['occurred_at'] ?? e['created_at'])?.toString();
         final ts = tsStr != null ? DateTime.tryParse(tsStr) : null;
+        final userId = e['user_id'] as String?;
+        final who = userId != null
+            ? (_usernames[userId] ??
+                (userId == Supabase.instance.client.auth.currentUser?.id
+                    ? l10n.you
+                    : ''))
+            : '';
+        final payload = e['payload'] as Map<String, dynamic>?;
+        final subtitleTime = ts != null ? dayTime.format(ts.toLocal()) : '';
+
+        String title;
+        switch (type) {
+          case 'KILL':
+            title =
+                who.isNotEmpty ? "$who ${l10n.killedEnemy}" : l10n.killedEnemy;
+            break;
+          case 'DEATH':
+            title = who.isNotEmpty ? "$who ${l10n.died}" : l10n.died;
+            break;
+          case 'STATUS_CHANGE':
+            final fromS = payload?['fromStatus'] as String?;
+            final toS = payload?['toStatus'] as String?;
+            title = _statusChangeText(l10n, who, fromS, toS);
+            break;
+          case 'JOIN':
+            title = who.isNotEmpty
+                ? "$who ${l10n.joinedTheSquad}"
+                : l10n.joinedTheSquad;
+            break;
+          case 'LEAVE':
+            title = who.isNotEmpty
+                ? "$who ${l10n.leftTheSquad}"
+                : l10n.leftTheSquad;
+            break;
+          case 'GAME_STARTED':
+            title = l10n.gameStarted;
+            break;
+          case 'GAME_ENDED':
+            title = l10n.gameEnded;
+            break;
+          case 'HOST_TRANSFER':
+            title = l10n.hostTransferred;
+            break;
+          default:
+            title = type;
+        }
         return ListTile(
           leading: Icon(_iconFor(type)),
-          title: Text(type),
-          subtitle: Text(ts != null ? dayTime.format(ts.toLocal()) : ''),
+          title: Text(title),
+          subtitle: Text(subtitleTime),
         );
       },
     );
+  }
+
+  String _statusChangeText(
+      AppLocalizations l10n, String who, String? fromS, String? toS) {
+    String label;
+    switch (toS) {
+      case 'ALIVE':
+        label = l10n.respawned;
+        break;
+      case 'HELP':
+        label = l10n.askForHelp;
+        break;
+      case 'MEDIC':
+        label = l10n.askForMedic;
+        break;
+      default:
+        label = l10n.statusActions;
+    }
+    return who.isNotEmpty ? "$who $label" : label;
   }
 }

--- a/lib/widgets/scoreboard/history_view.dart
+++ b/lib/widgets/scoreboard/history_view.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
+import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
+import 'package:squad_tracker_flutter/providers/game_service.dart';
+
+class HistoryView extends StatefulWidget {
+  final int gameId;
+  const HistoryView({super.key, required this.gameId});
+
+  @override
+  State<HistoryView> createState() => _HistoryViewState();
+}
+
+class _HistoryViewState extends State<HistoryView> {
+  final _gameService = GameService();
+  List<Map<String, dynamic>> _events = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _gameService.getGameEvents(widget.gameId);
+    setState(() => _events = data);
+  }
+
+  IconData _iconFor(String type) {
+    switch (type) {
+      case 'KILL':
+        return Icons.check_circle_outline;
+      case 'DEATH':
+        return Icons.close_rounded;
+      case 'STATUS_CHANGE':
+        return Icons.flag_outlined;
+      case 'JOIN':
+        return Icons.person_add_alt_1;
+      case 'LEAVE':
+        return Icons.exit_to_app;
+      case 'GAME_STARTED':
+        return Icons.play_arrow_rounded;
+      case 'GAME_ENDED':
+        return Icons.stop_circle_outlined;
+      case 'HOST_TRANSFER':
+        return Icons.star_outline;
+    }
+    return Icons.bolt;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    if (_events.isEmpty) {
+      return Center(child: Text(l10n.noEventsYet));
+    }
+    final dayTime = DateFormat.yMMMd().add_jm();
+    return ListView.separated(
+      itemCount: _events.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final e = _events[index];
+        final type = (e['event_type'] as String?) ?? '';
+        final tsStr = (e['occurred_at'] ?? e['created_at'])?.toString();
+        final ts = tsStr != null ? DateTime.tryParse(tsStr) : null;
+        return ListTile(
+          leading: Icon(_iconFor(type)),
+          title: Text(type),
+          subtitle: Text(ts != null ? dayTime.format(ts.toLocal()) : ''),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/scoreboard/leaderboard_view.dart
+++ b/lib/widgets/scoreboard/leaderboard_view.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:squad_tracker_flutter/l10n/gen/app_localizations.dart';
+import 'package:squad_tracker_flutter/l10n/localizations_extensions.dart';
+import 'package:squad_tracker_flutter/providers/game_service.dart';
+
+enum LeaderboardSort { kills, kdr, streak }
+
+class LeaderboardView extends StatefulWidget {
+  final int gameId;
+  const LeaderboardView({super.key, required this.gameId});
+
+  @override
+  State<LeaderboardView> createState() => _LeaderboardViewState();
+}
+
+class _LeaderboardViewState extends State<LeaderboardView> {
+  final _gameService = GameService();
+  LeaderboardSort _sort = LeaderboardSort.kills;
+  List<Map<String, dynamic>> _rows = const [];
+  bool _hasStreakData = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _gameService.getFinalScoreboard(widget.gameId);
+    final hasStreak = data.any((r) => r['max_kill_streak'] != null);
+    setState(() {
+      _rows = data;
+      _hasStreakData = hasStreak;
+    });
+  }
+
+  double _kdr(num kills, num deaths) {
+    final k = kills.toDouble();
+    final d = deaths.toDouble();
+    if (k == 0 && d == 0) return -1; // special marker for display "—"
+    if (d == 0) return k; // treat as kills
+    return k / d;
+  }
+
+  List<Map<String, dynamic>> _sorted() {
+    final copy = [..._rows];
+    switch (_sort) {
+      case LeaderboardSort.kills:
+        copy.sort((a, b) {
+          final ka = (a['kills'] as num?)?.toInt() ?? 0;
+          final kb = (b['kills'] as num?)?.toInt() ?? 0;
+          if (kb != ka) return kb.compareTo(ka);
+          final da = (a['deaths'] as num?)?.toInt() ?? 0;
+          final db = (b['deaths'] as num?)?.toInt() ?? 0;
+          if (da != db) return da.compareTo(db);
+          final ua = (a['username'] as String?) ?? '';
+          final ub = (b['username'] as String?) ?? '';
+          return ua.compareTo(ub);
+        });
+        break;
+      case LeaderboardSort.kdr:
+        copy.sort((a, b) {
+          final kdra = _kdr(a['kills'] ?? 0, a['deaths'] ?? 0);
+          final kdrb = _kdr(b['kills'] ?? 0, b['deaths'] ?? 0);
+          if (kdrb != kdra) return kdrb.compareTo(kdra);
+          final ka = (a['kills'] as num?)?.toInt() ?? 0;
+          final kb = (b['kills'] as num?)?.toInt() ?? 0;
+          if (kb != ka) return kb.compareTo(ka);
+          final da = (a['deaths'] as num?)?.toInt() ?? 0;
+          final db = (b['deaths'] as num?)?.toInt() ?? 0;
+          if (da != db) return da.compareTo(db);
+          final ua = (a['username'] as String?) ?? '';
+          final ub = (b['username'] as String?) ?? '';
+          return ua.compareTo(ub);
+        });
+        break;
+      case LeaderboardSort.streak:
+        copy.sort((a, b) {
+          final sa = (a['max_kill_streak'] as num?)?.toInt() ?? -1;
+          final sb = (b['max_kill_streak'] as num?)?.toInt() ?? -1;
+          if (sb != sa) return sb.compareTo(sa);
+          final ka = (a['kills'] as num?)?.toInt() ?? 0;
+          final kb = (b['kills'] as num?)?.toInt() ?? 0;
+          if (kb != ka) return kb.compareTo(ka);
+          final da = (a['deaths'] as num?)?.toInt() ?? 0;
+          final db = (b['deaths'] as num?)?.toInt() ?? 0;
+          if (da != db) return da.compareTo(db);
+          final ua = (a['username'] as String?) ?? '';
+          final ub = (b['username'] as String?) ?? '';
+          return ua.compareTo(ub);
+        });
+        break;
+    }
+    return copy;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final rows = _sorted();
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 8,
+            children: [
+              ChoiceChip(
+                label: Text(l10n.sortByKills),
+                selected: _sort == LeaderboardSort.kills,
+                onSelected: (_) =>
+                    setState(() => _sort = LeaderboardSort.kills),
+              ),
+              ChoiceChip(
+                label: Text(l10n.sortByKDR),
+                selected: _sort == LeaderboardSort.kdr,
+                onSelected: (_) => setState(() => _sort = LeaderboardSort.kdr),
+              ),
+              if (_hasStreakData)
+                ChoiceChip(
+                  label: Text(l10n.sortByStreak),
+                  selected: _sort == LeaderboardSort.streak,
+                  onSelected: (_) =>
+                      setState(() => _sort = LeaderboardSort.streak),
+                ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.separated(
+            itemCount: rows.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final r = rows[index];
+              final kills = (r['kills'] as num?)?.toInt() ?? 0;
+              final deaths = (r['deaths'] as num?)?.toInt() ?? 0;
+              final kdr = _kdr(kills, deaths);
+              final rank = index + 1;
+              return ListTile(
+                leading: CircleAvatar(child: Text(rank.toString())),
+                title: Text((r['username'] as String?) ?? '—'),
+                subtitle: Text(
+                  '${l10n.killsLabel}: $kills · ${l10n.deathsLabel}: $deaths · ${l10n.kdLabel}: ${kdr < 0 ? '—' : kdr.toStringAsFixed(2)}',
+                ),
+                trailing: _hasStreakData
+                    ? Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.local_fire_department,
+                              color: Colors.orange),
+                          const SizedBox(width: 4),
+                          Text('${r['max_kill_streak'] ?? 0}')
+                        ],
+                      )
+                    : null,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Introduced a new `FinalReportOverlay` widget to display game results, including leaderboard and event history.
- Implemented methods in `GameService` to fetch final scoreboards and game events, improving data retrieval for completed games.
- Enhanced `MapWithLocation` and `SquadLobbyScreen` to support displaying past games and final reports, providing users with better access to game history.
- Updated localization strings for new UI elements, ensuring clarity in user interactions.